### PR TITLE
chore: WSC-1640 upgrade package version to 0.1.5

### DIFF
--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-message-broker"
-pkgver="0.1.4"
+pkgver="0.1.5"
 pkgrel="1"
 pkgdesc="Carbonio message broker"
 url="https://www.zextras.com/"


### PR DESCRIPTION
this is necessary to build the package with the new carbonio-erlang