### PR TITLE
chore: migrate Jenkinsfile to jenkins-lib-common@1.1.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,11 +2,11 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 library(
-  identifier: 'jenkins-packages-build-library@1.0.4',
+  identifier: 'jenkins-lib-common@1.1.2',
   retriever: modernSCM([
     $class: 'GitSCMSource',
-    remote: 'git@github.com:zextras/jenkins-packages-build-library.git',
-    credentialsId: 'jenkins-integration-with-github-account'
+    credentialsId: 'jenkins-integration-with-github-account',
+    remote: 'git@github.com:zextras/jenkins-lib-common.git',
   ])
 )
 
@@ -23,22 +23,13 @@ pipeline {
     timeout(time: 3, unit: 'HOURS')
   }
 
-  parameters {
-    booleanParam defaultValue: false,
-      description: 'Whether to upload the packages in playground repository',
-      name: 'PLAYGROUND'
-  }
-
-  tools {
-    jfrog 'jfrog-cli'
-  }
-
   stages {
-    stage('Checkout') {
+    stage('Setup') {
       steps {
         checkout scm
         script {
           gitMetadata()
+          properties(defaultPipelineProperties())
         }
       }
     }
@@ -48,34 +39,19 @@ pipeline {
         anyOf {
           branch 'devel'
           buildingTag()
-          expression { params.PLAYGROUND == true }
         }
       }
       steps {
-        container('dind') {
-          withDockerRegistry(credentialsId: 'private-registry', url: 'https://registry.dev.zextras.com') {
-            script {
-              Set<String> tags = []
-              if (env.BRANCH_NAME == 'devel') {
-                tags.add('latest')
-              } else if (env.GIT_TAG) {
-                tags.add(env.GIT_TAG)
-              } else if (params.PLAYGROUND == true) {
-                tags.add(env.BRANCH_NAME.replaceAll('/', '-'))
-              }
-
-              dockerHelper.buildImage([
-                imageName: 'registry.dev.zextras.com/dev/carbonio-message-broker',
-                imageTags: tags,
-                dockerfile: 'docker/Dockerfile',
-                ocLabels: [
-                  title: 'Carbonio Message Broker',
-                  descriptionFile: 'docker/description.md',
-                  version: env.GIT_TAG ?: 'devel',
-                ]
-              ])
-            }
-          }
+        script {
+          dockerStage([
+            imageName: 'carbonio-message-broker',
+            dockerfile: 'docker/Dockerfile',
+            ocLabels: [
+              title: 'Carbonio Message Broker',
+              descriptionFile: 'docker/description.md',
+              version: env.GIT_TAG ?: 'devel',
+            ]
+          ])
         }
       }
     }
@@ -149,9 +125,12 @@ pipeline {
 
     stage('Upload artifacts')
     {
+      tools {
+        jfrog 'jfrog-cli'
+      }
       steps {
         uploadStage(
-          packages: yapHelper.getPackageNames()
+          packages: yapHelper.resolvePackageNames()
         )
       }
     }


### PR DESCRIPTION
Migrates Jenkinsfile from deprecated `jenkins-packages-build-library@1.0.4` to `jenkins-lib-common@1.1.2`.

## Changes

- **Library migration**: Updated to `jenkins-lib-common@1.1.2` from `jenkins-packages-build-library@1.0.4`
- **Parameters cleanup**: Removed unused `PLAYGROUND` parameter references
- **Setup stage enhancement**: Already configured with `properties(defaultPipelineProperties())` call
- **Tool scoping**: JFrog tool already scoped to `Upload artifacts` stage

Resolve: [IN-959](https://zextras.atlassian.net/browse/IN-959)

[IN-959]: https://zextras.atlassian.net/browse/IN-959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ