### PR TITLE
chore: add renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>zextras/infra-renovate-config:default",
+    "github>zextras/infra-renovate-config",
     "github>zextras/infra-renovate-config:docker"
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>zextras/infra-renovate-config:default",
+    "github>zextras/infra-renovate-config:docker"
+  ]
+}

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-message-broker"
-pkgver="0.2.2" # renovate: datasource=github-releases depName=rabbitmq/rabbitmq-server
+pkgver="0.2.2"
 pkgrel="1"
 pkgdesc="Carbonio message broker"
 url="https://www.zextras.com/"

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-message-broker"
-pkgver="0.2.2"
+pkgver="0.2.2" # renovate: datasource=github-releases depName=rabbitmq/rabbitmq-server
 pkgrel="1"
 pkgdesc="Carbonio message broker"
 url="https://www.zextras.com/"


### PR DESCRIPTION
## Summary

This PR migrates the repository to use Renovate for automated dependency management.

## Changes

- Add Renovate configuration based on detected tech stack
- Remove Dependabot configuration (if present)
- Configure automated dependency updates according to Zextras standards

## Tech Stack Detected

The configuration has been tailored for the technologies detected in this repository.

## Benefits

- Centralized dependency management configuration
- Better grouping of related dependency updates
- More flexible scheduling and update strategies
- Improved security vulnerability handling

Refs: IN-948