### PR TITLE
chore(ci): update jenkins library pipeline configuration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,8 @@ library(
   ])
 )
 
+properties(defaultPipelineProperties())
+
 pipeline {
   agent {
     node {
@@ -29,7 +31,6 @@ pipeline {
         checkout scm
         script {
           gitMetadata()
-          properties(defaultPipelineProperties())
         }
       }
     }


### PR DESCRIPTION
Applies Jenkins library improvements from spec files:

## Changes
- **default-pipeline-properties**: Moved `properties(defaultPipelineProperties())` from inside the Setup stage to top-level scope after library imports

This change ensures Jenkins pipeline properties are configured at the correct execution point in the pipeline lifecycle.

Refs: IN-982