### PR TITLE
chore: [CO-3496] define sidecar image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,6 +57,23 @@ pipeline {
             }
         }
 
+        stage('Build and Publish Docker Images') {
+            steps {
+                buildAndPublishDockerImage(
+                        projectName: 'carbonio-message-broker',
+                        dockerfile: 'docker/Dockerfile',
+                        imageTitle: 'Carbonio Message Broker',
+                        imageDescription: 'Carbonio Message Broker Service'
+                )
+                buildAndPublishDockerImage(
+                        projectName: 'carbonio-message-broker-sidecar',
+                        dockerfile: 'docker/sidecar/Dockerfile',
+                        imageTitle: 'Carbonio Message Broker Sidecar',
+                        imageDescription: 'Carbonio Message Broker Sidecar Service'
+                )
+            }
+        }
+
         stage('Build deb/rpm') {
             steps {
                 script {
@@ -124,22 +141,6 @@ pipeline {
                 script {
                     tagRelease()
                 }
-            }
-        }
-
-        stage('Build and Publish Docker Image') {
-            when {
-                not {
-                    expression { env.BRANCH_NAME.startsWith('PR-') }
-                }
-            }
-            steps {
-                buildAndPublishDockerImage(
-                    projectName: 'carbonio-message-broker',
-                    dockerfile: 'docker/Dockerfile',
-                    imageTitle: 'Carbonio Message Broker',
-                    imageDescription: 'Carbonio Message Broker Service'
-                )
             }
         }
     }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,9 @@ FROM rabbitmq:4.2.5-management-alpine
 COPY docker/conf/rabbitmq.conf /etc/rabbitmq/rabbitmq.conf
 COPY docker/conf/default_schema.json /etc/rabbitmq/default_schema.json
 
+# Install consul CLI for setup-users script (consul KV access)
+COPY --from=docker.io/hashicorp/consul:1.21 /bin/consul /usr/local/bin/consul
+
 COPY package/carbonio-message-broker-setup-users /usr/local/bin/carbonio-message-broker-setup-users
 RUN chmod +x /usr/local/bin/carbonio-message-broker-setup-users
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,10 @@ COPY docker/conf/default_schema.json /etc/rabbitmq/default_schema.json
 COPY --from=docker.io/hashicorp/consul:1.21 /bin/consul /usr/local/bin/consul
 
 COPY package/carbonio-message-broker-setup-users /usr/local/bin/carbonio-message-broker-setup-users
-RUN chmod +x /usr/local/bin/carbonio-message-broker-setup-users
+COPY docker/entrypoint.sh /usr/local/bin/carbonio-message-broker-entrypoint
+RUN chmod +x /usr/local/bin/carbonio-message-broker-setup-users \
+             /usr/local/bin/carbonio-message-broker-entrypoint
 
 EXPOSE 10000 10001
+
+ENTRYPOINT ["carbonio-message-broker-entrypoint"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,7 @@ COPY docker/entrypoint.sh /usr/local/bin/carbonio-message-broker-entrypoint
 RUN chmod +x /usr/local/bin/carbonio-message-broker-setup-users \
              /usr/local/bin/carbonio-message-broker-entrypoint
 
+ENV CONSUL_SETUP=false
 EXPOSE 10000 10001
 
 ENTRYPOINT ["carbonio-message-broker-entrypoint"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,4 +3,7 @@ FROM rabbitmq:4.2.5-management-alpine
 COPY docker/conf/rabbitmq.conf /etc/rabbitmq/rabbitmq.conf
 COPY docker/conf/default_schema.json /etc/rabbitmq/default_schema.json
 
+COPY package/carbonio-message-broker-setup-users /usr/local/bin/carbonio-message-broker-setup-users
+RUN chmod +x /usr/local/bin/carbonio-message-broker-setup-users
+
 EXPOSE 10000 10001

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+echo "[message-broker] Waiting for consul agent..."
+until consul members >/dev/null 2>&1; do sleep 1; done
+echo "[message-broker] Consul agent ready."
+
 # Wait for RabbitMQ to be ready, then run setup-users in background
 (
   echo "Waiting for RabbitMQ to be ready..."

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Wait for RabbitMQ to be ready, then run setup-users in background
+(
+  echo "Waiting for RabbitMQ to be ready..."
+  until rabbitmqctl status >/dev/null 2>&1; do sleep 2; done
+  echo "RabbitMQ is ready, running setup-users..."
+  carbonio-message-broker-setup-users
+) &
+
+# Exec into the original RabbitMQ entrypoint
+exec docker-entrypoint.sh rabbitmq-server

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
 
-echo "[message-broker] Waiting for consul agent..."
-until consul members >/dev/null 2>&1; do sleep 1; done
-echo "[message-broker] Consul agent ready."
+if [ "${CONSUL_SETUP}" != "false" ]; then
+  echo "[message-broker] Waiting for consul agent..."
+  until consul members >/dev/null 2>&1; do sleep 1; done
+  echo "[message-broker] Consul agent ready."
 
-# Wait for RabbitMQ to be ready, then run setup-users in background
-(
-  echo "Waiting for RabbitMQ to be ready..."
-  until rabbitmqctl status >/dev/null 2>&1; do sleep 2; done
-  echo "RabbitMQ is ready, running setup-users..."
-  carbonio-message-broker-setup-users
-) &
+  # Wait for RabbitMQ to be ready, then run setup-users in background
+  (
+    echo "Waiting for RabbitMQ to be ready..."
+    until rabbitmqctl status >/dev/null 2>&1; do sleep 2; done
+    echo "RabbitMQ is ready, running setup-users..."
+    carbonio-message-broker-setup-users
+  ) &
+fi
 
 # Exec into the original RabbitMQ entrypoint
 exec docker-entrypoint.sh rabbitmq-server

--- a/docker/sidecar/Dockerfile
+++ b/docker/sidecar/Dockerfile
@@ -9,9 +9,9 @@ COPY package/intentions.json       /etc/carbonio/message-broker/service-discover
 COPY package/policies.json         /etc/carbonio/message-broker/service-discover/
 
 # Setup script
-COPY docker/sidecar/carbonio-message-broker-setup /usr/local/bin/carbonio-message-broker-setup
-RUN chmod +x /usr/local/bin/carbonio-message-broker-setup
+COPY package/carbonio-message-broker /usr/local/bin/carbonio-message-broker
+RUN chmod +x /usr/local/bin/carbonio-message-broker
 
 ENV SERVICE_NAME=carbonio-message-broker
-ENV SETUP_SCRIPT="carbonio-message-broker-setup"
+ENV SETUP_SCRIPT="carbonio-message-broker setup"
 ENV TOKEN_FILE=/etc/carbonio/message-broker/service-discover/token

--- a/docker/sidecar/Dockerfile
+++ b/docker/sidecar/Dockerfile
@@ -9,7 +9,7 @@ COPY package/intentions.json       /etc/carbonio/message-broker/service-discover
 COPY package/policies.json         /etc/carbonio/message-broker/service-discover/
 
 # Setup script
-COPY package/141-carbonio-message-broker-setup.sh /usr/local/bin/carbonio-message-broker-setup
+COPY docker/sidecar/carbonio-message-broker-setup /usr/local/bin/carbonio-message-broker-setup
 RUN chmod +x /usr/local/bin/carbonio-message-broker-setup
 
 ENV SERVICE_NAME=carbonio-message-broker

--- a/docker/sidecar/Dockerfile
+++ b/docker/sidecar/Dockerfile
@@ -1,0 +1,17 @@
+FROM registry.dev.zextras.com/dev/carbonio-sidecar:latest
+
+# Service registration
+COPY package/carbonio-message-broker.hcl /consul/config/
+
+# Setup files
+COPY package/service-protocol.json /etc/carbonio/message-broker/service-discover/
+COPY package/intentions.json       /etc/carbonio/message-broker/service-discover/
+COPY package/policies.json         /etc/carbonio/message-broker/service-discover/
+
+# Setup script
+COPY package/141-carbonio-message-broker-setup.sh /usr/local/bin/carbonio-message-broker-setup
+RUN chmod +x /usr/local/bin/carbonio-message-broker-setup
+
+ENV SERVICE_NAME=carbonio-message-broker
+ENV SETUP_SCRIPT="carbonio-message-broker-setup"
+ENV TOKEN_FILE=/etc/carbonio/message-broker/service-discover/token


### PR DESCRIPTION
Adds:
- mesage broker sidecar
- consul registration (username, password) to Consul KV 

TODO: 
- [x] think about defining a new image for rabbitmq to avoid breaking docker compose
- [x] think about running consul setup as an option (e.g.: SETUP=true as env) -> opted for this one