### PR TITLE
ci: pin jenkins-lib-common to v3.5.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'jenkins-lib-common@v3.5.0',
+    identifier: 'jenkins-lib-common@v3.5.1',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',


### PR DESCRIPTION
Bump the `jenkins-lib-common` shared library tag to `v3.5.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)