### PR TITLE
fix(ci): restore arm64 platforms for both docker images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,12 +26,14 @@ dt3_pipeline(
     docker: [
         [
             dockerfile: 'docker/Dockerfile',
+            platforms: ['linux/amd64', 'linux/arm64'] as Set,
             imageName: 'carbonio-message-broker',
             title: 'Carbonio Message Broker',
             description: 'Carbonio Message Broker Service',
         ],
         [
             dockerfile: 'docker/sidecar/Dockerfile',
+            platforms: ['linux/amd64', 'linux/arm64'] as Set,
             imageName: 'carbonio-message-broker-sidecar',
             title: 'Carbonio Message Broker Sidecar',
             description: 'Carbonio Message Broker Sidecar Service',


### PR DESCRIPTION
`carbonio-message-broker(-sidecar):devel` is amd64-only, so arm64 clusters get `ImagePullBackOff: no match for platform in manifest`.

PR #94 added the `platforms` key; PR #93 removed it — it branched before #94 landed and its merge-back (`8b7ca6a4`, *"keep generated files (ours)"*) took its own pre-#94 Jenkinsfile.

```
$ git log -S "platforms" --oneline -- Jenkinsfile
1c9dcb7  ci: introduce pre-commit and verify-only generation setup (#93)   ← removed
f9a0e86  feat(IN-951): add aarch64 container images support (#94)          ← added
```

Nothing went red: `jenkins-lib-common` defaults to amd64 (`dockerHelper.groovy:14`). Registry tags confirm the cutover — `624f2022` (0.5.1) is multi-arch, `8b7ca6a4` and everything after (incl. `devel`) is not.

This restores the two lines verbatim; the `docker:` block is now byte-identical to `f9a0e86`. No lib bump needed — `v4.7.0` already honours the key (`dt3_pipeline.groovy:811`).

Verify once CI publishes:

```bash
docker manifest inspect registry.dev.zextras.com/dev/carbonio-message-broker:devel \
  | jq -r '.manifests[].platform.architecture' | sort -u   # expect: amd64, arm64
```

ref: IN-951